### PR TITLE
support String in sequencematcher.rs

### DIFF
--- a/src/sequencematcher.rs
+++ b/src/sequencematcher.rs
@@ -74,6 +74,32 @@ impl<'a> Sequence for Vec<&'a str> {
 	}
 }
 
+impl Sequence for String {
+    fn len(&self) -> usize {
+        self.len()
+    }   
+
+    fn at_index(&self, index: usize) -> Option<&str> {
+        if index > self.len() {
+            return None;
+        }
+        unsafe { Some(self.slice_unchecked(index, index + 1)) }
+    }   
+}
+
+impl<'a> Sequence for Vec<String> {
+    fn len(&self) -> usize {
+        self.len()
+    }   
+
+    fn at_index(&self, index: usize) -> Option<&str> {
+        if index < self.len() {
+            return Some(&self[index]);
+        }
+        None
+    }   
+}
+
 pub struct SequenceMatcher<'a, T: 'a + ?Sized + Sequence>{
 	first_sequence: &'a T,
 	second_sequence: &'a T,


### PR DESCRIPTION
Hi, difflib is a great utility, but doesn't support String and Vec<String> which was trivial to add.

Would you consider this pull request?