### PR TITLE
 Make SequenceMatcher generic over all slice types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "difflib"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Dima Kudosh <dimakudosh@gmail.com>"]
 description = "Port of Python's difflib library to Rust."
 documentation = "https://github.com/DimaKudosh/difflib/wiki"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Simply add difflib to your dependencies block in Cargo.toml
 
 ```rust
 [dependencies]
-difflib = "0.3.0"
+difflib = "0.4.0"
 ```
 
 ## Documentation
@@ -65,7 +65,7 @@ fn main() {
     }
 
     //SequenceMatcher examples
-    let mut matcher = SequenceMatcher::new("one two three four", "zero one tree four");
+    let mut matcher = SequenceMatcher::new(b"one two three four", b"zero one tree four");
     let m = matcher.find_longest_match(0, 18, 0, 18);
     println!("{:?}", m);
     let all_matches = matcher.get_matching_blocks();
@@ -76,7 +76,7 @@ fn main() {
     println!("{:?}", grouped_opcodes);
     let ratio = matcher.ratio();
     println!("{:?}", ratio);
-    matcher.set_seqs("aaaaa", "aaaab");
+    matcher.set_seqs(b"aaaaa", b"aaaab");
     println!("{:?}", matcher.ratio());
 }
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ fn main() {
     }
 
     //SequenceMatcher examples
-    let mut matcher = SequenceMatcher::new(b"one two three four", b"zero one tree four");
+    let mut matcher = SequenceMatcher::new("one two three four", "zero one tree four");
     let m = matcher.find_longest_match(0, 18, 0, 18);
     println!("{:?}", m);
     let all_matches = matcher.get_matching_blocks();
@@ -76,7 +76,7 @@ fn main() {
     println!("{:?}", grouped_opcodes);
     let ratio = matcher.ratio();
     println!("{:?}", ratio);
-    matcher.set_seqs(b"aaaaa", b"aaaab");
+    matcher.set_seqs("aaaaa", "aaaab");
     println!("{:?}", matcher.ratio());
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Difflib [![Build Status](https://travis-ci.org/DimaKudosh/difflib.svg?branch=master)](https://travis-ci.org/DimaKudosh/difflib)
 
-Port of Python's difflib library to Rust. 
+Port of Python's difflib library to Rust.
 It's provide all necessary tools for comparing word sequences.
 
 ## Installation
@@ -21,20 +21,33 @@ extern crate difflib;
 use difflib::differ::Differ;
 use difflib::sequencematcher::SequenceMatcher;
 
-
 fn main() {
     // unified_diff
     let first_text = "one two three four".split(" ").collect::<Vec<&str>>();
     let second_text = "zero one tree four".split(" ").collect::<Vec<&str>>();
-    let diff = difflib::unified_diff(&first_text, &second_text, "Original", "Current",
-             "2005-01-26 23:30:50", "2010-04-02 10:20:52", 3);
+    let diff = difflib::unified_diff(
+        &first_text,
+        &second_text,
+        "Original",
+        "Current",
+        "2005-01-26 23:30:50",
+        "2010-04-02 10:20:52",
+        3,
+    );
     for line in &diff {
         println!("{:?}", line);
     }
 
     //context_diff
-    let diff = difflib::context_diff(&first_text, &second_text, "Original", "Current",
-             "2005-01-26 23:30:50", "2010-04-02 10:20:52", 3);
+    let diff = difflib::context_diff(
+        &first_text,
+        &second_text,
+        "Original",
+        "Current",
+        "2005-01-26 23:30:50",
+        "2010-04-02 10:20:52",
+        3,
+    );
     for line in &diff {
         println!("{:?}", line);
     }
@@ -62,7 +75,7 @@ fn main() {
     let grouped_opcodes = matcher.get_grouped_opcodes(2);
     println!("{:?}", grouped_opcodes);
     let ratio = matcher.ratio();
-    println!("{:?}", ratio); 
+    println!("{:?}", ratio);
     matcher.set_seqs("aaaaa", "aaaab");
     println!("{:?}", matcher.ratio());
 }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -47,7 +47,7 @@ fn main() {
     }
 
     //SequenceMatcher examples
-    let mut matcher = SequenceMatcher::new(b"one two three four", b"zero one tree four");
+    let mut matcher = SequenceMatcher::new("one two three four", "zero one tree four");
     let m = matcher.find_longest_match(0, 18, 0, 18);
     println!("{:?}", m);
     let all_matches = matcher.get_matching_blocks();
@@ -58,6 +58,6 @@ fn main() {
     println!("{:?}", grouped_opcodes);
     let ratio = matcher.ratio();
     println!("{:?}", ratio);
-    matcher.set_seqs(b"aaaaa", b"aaaab");
+    matcher.set_seqs("aaaaa", "aaaab");
     println!("{:?}", matcher.ratio());
 }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -47,7 +47,7 @@ fn main() {
     }
 
     //SequenceMatcher examples
-    let mut matcher = SequenceMatcher::new("one two three four", "zero one tree four");
+    let mut matcher = SequenceMatcher::new(b"one two three four", b"zero one tree four");
     let m = matcher.find_longest_match(0, 18, 0, 18);
     println!("{:?}", m);
     let all_matches = matcher.get_matching_blocks();
@@ -58,6 +58,6 @@ fn main() {
     println!("{:?}", grouped_opcodes);
     let ratio = matcher.ratio();
     println!("{:?}", ratio);
-    matcher.set_seqs("aaaaa", "aaaab");
+    matcher.set_seqs(b"aaaaa", b"aaaab");
     println!("{:?}", matcher.ratio());
 }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -3,30 +3,33 @@ extern crate difflib;
 use difflib::differ::Differ;
 use difflib::sequencematcher::SequenceMatcher;
 
-
 fn main() {
     // unified_diff
     let first_text = "one two three four".split(" ").collect::<Vec<&str>>();
     let second_text = "zero one tree four".split(" ").collect::<Vec<&str>>();
-    let diff = difflib::unified_diff(&first_text,
-                                     &second_text,
-                                     "Original",
-                                     "Current",
-                                     "2005-01-26 23:30:50",
-                                     "2010-04-02 10:20:52",
-                                     3);
+    let diff = difflib::unified_diff(
+        &first_text,
+        &second_text,
+        "Original",
+        "Current",
+        "2005-01-26 23:30:50",
+        "2010-04-02 10:20:52",
+        3,
+    );
     for line in &diff {
         println!("{:?}", line);
     }
 
     //context_diff
-    let diff = difflib::context_diff(&first_text,
-                                     &second_text,
-                                     "Original",
-                                     "Current",
-                                     "2005-01-26 23:30:50",
-                                     "2010-04-02 10:20:52",
-                                     3);
+    let diff = difflib::context_diff(
+        &first_text,
+        &second_text,
+        "Original",
+        "Current",
+        "2005-01-26 23:30:50",
+        "2010-04-02 10:20:52",
+        3,
+    );
     for line in &diff {
         println!("{:?}", line);
     }

--- a/src/differ.rs
+++ b/src/differ.rs
@@ -4,8 +4,8 @@ use utils::{count_leading, str_with_similar_chars};
 
 #[derive(Default)]
 pub struct Differ {
-    pub line_junk: Option<fn(&str) -> bool>,
-    pub char_junk: Option<fn(&str) -> bool>,
+    pub line_junk: Option<fn(&&str) -> bool>,
+    pub char_junk: Option<fn(&char) -> bool>,
 }
 
 impl Differ {
@@ -123,7 +123,12 @@ impl Differ {
                     }
                     continue;
                 }
-                let mut cruncher = SequenceMatcher::new(*first_sequence_str, *second_sequence_str);
+                let (first_sequence_chars, second_sequence_chars) = (
+                    first_sequence_str.chars().collect::<Vec<char>>(),
+                    second_sequence_str.chars().collect::<Vec<char>>(),
+                );
+                let mut cruncher =
+                    SequenceMatcher::new(&first_sequence_chars, &second_sequence_chars);
                 cruncher.set_is_junk(self.char_junk);
                 if cruncher.ratio() > best_ratio {
                     best_ratio = cruncher.ratio();
@@ -167,7 +172,9 @@ impl Differ {
         let second_element = &second_sequence[best_j];
         if eqi.is_none() {
             let (mut first_tag, mut second_tag) = (String::new(), String::new());
-            let mut cruncher = SequenceMatcher::new(*first_element, second_element);
+            let first_element_chars: Vec<char> = first_element.chars().collect();
+            let second_element_chars: Vec<char> = second_element.chars().collect();
+            let mut cruncher = SequenceMatcher::new(&first_element_chars, &second_element_chars);
             cruncher.set_is_junk(self.char_junk);
             for opcode in &cruncher.get_opcodes() {
                 let (first_length, second_length) = (

--- a/src/differ.rs
+++ b/src/differ.rs
@@ -1,7 +1,6 @@
-use sequencematcher::{SequenceMatcher, Sequence};
-use utils::{str_with_similar_chars, count_leading};
+use sequencematcher::{Sequence, SequenceMatcher};
 use std::cmp;
-
+use utils::{count_leading, str_with_similar_chars};
 
 pub struct Differ {
     pub line_junk: Option<fn(&str) -> bool>,
@@ -16,10 +15,11 @@ impl Differ {
         }
     }
 
-    pub fn compare<T: ?Sized + Sequence>(&self,
-                                         first_sequence: &T,
-                                         second_sequence: &T)
-                                         -> Vec<String> {
+    pub fn compare<T: ?Sized + Sequence>(
+        &self,
+        first_sequence: &T,
+        second_sequence: &T,
+    ) -> Vec<String> {
         let mut matcher = SequenceMatcher::new(first_sequence, second_sequence);
         matcher.set_is_junk(self.line_junk);
         let mut res = Vec::new();
@@ -27,12 +27,14 @@ impl Differ {
             let mut gen = Vec::new();
             match opcode.tag.as_ref() {
                 "replace" => {
-                    gen = self.fancy_replace(first_sequence,
-                                             opcode.first_start,
-                                             opcode.first_end,
-                                             second_sequence,
-                                             opcode.second_start,
-                                             opcode.second_end)
+                    gen = self.fancy_replace(
+                        first_sequence,
+                        opcode.first_start,
+                        opcode.first_end,
+                        second_sequence,
+                        opcode.second_start,
+                        opcode.second_end,
+                    )
                 }
                 "delete" => {
                     gen = self.dump("-", first_sequence, opcode.first_start, opcode.first_end)
@@ -52,12 +54,13 @@ impl Differ {
         res
     }
 
-    fn dump<T: ?Sized + Sequence>(&self,
-                                  tag: &str,
-                                  sequence: &T,
-                                  start: usize,
-                                  end: usize)
-                                  -> Vec<String> {
+    fn dump<T: ?Sized + Sequence>(
+        &self,
+        tag: &str,
+        sequence: &T,
+        start: usize,
+        end: usize,
+    ) -> Vec<String> {
         let mut res = Vec::new();
         for i in start..end {
             match sequence.at_index(i) {
@@ -68,14 +71,15 @@ impl Differ {
         res
     }
 
-    fn plain_replace<T: ?Sized + Sequence>(&self,
-                                           first_sequence: &T,
-                                           first_start: usize,
-                                           first_end: usize,
-                                           second_sequence: &T,
-                                           second_start: usize,
-                                           second_end: usize)
-                                           -> Vec<String> {
+    fn plain_replace<T: ?Sized + Sequence>(
+        &self,
+        first_sequence: &T,
+        first_start: usize,
+        first_end: usize,
+        second_sequence: &T,
+        second_start: usize,
+        second_end: usize,
+    ) -> Vec<String> {
         if !(first_start < first_end && second_start < second_end) {
             return Vec::new();
         }
@@ -94,14 +98,15 @@ impl Differ {
         first
     }
 
-    fn fancy_replace<T: ?Sized + Sequence>(&self,
-                                           first_sequence: &T,
-                                           first_start: usize,
-                                           first_end: usize,
-                                           second_sequence: &T,
-                                           second_start: usize,
-                                           second_end: usize)
-                                           -> Vec<String> {
+    fn fancy_replace<T: ?Sized + Sequence>(
+        &self,
+        first_sequence: &T,
+        first_start: usize,
+        first_end: usize,
+        second_sequence: &T,
+        second_start: usize,
+        second_end: usize,
+    ) -> Vec<String> {
         let mut res = Vec::new();
         let (mut best_ratio, cutoff) = (0.74, 0.75);
         let (mut best_i, mut best_j) = (0, 0);
@@ -130,14 +135,17 @@ impl Differ {
         }
         if best_ratio < cutoff {
             if eqi.is_none() {
-                res.extend(self.plain_replace(first_sequence,
-                                   first_start,
-                                   first_end,
-                                   second_sequence,
-                                   second_start,
-                                   second_end)
-                    .iter()
-                    .cloned());
+                res.extend(
+                    self.plain_replace(
+                        first_sequence,
+                        first_start,
+                        first_end,
+                        second_sequence,
+                        second_start,
+                        second_end,
+                    ).iter()
+                        .cloned(),
+                );
                 return res;
             }
             best_i = eqi.unwrap();
@@ -145,23 +153,30 @@ impl Differ {
         } else {
             eqi = None;
         }
-        res.extend(self.fancy_helper(first_sequence,
-                          first_start,
-                          best_i,
-                          second_sequence,
-                          second_start,
-                          best_j)
-            .iter()
-            .cloned());
-        let (first_element, second_element) = (first_sequence.at_index(best_i).unwrap(),
-                                               second_sequence.at_index(best_j).unwrap());
+        res.extend(
+            self.fancy_helper(
+                first_sequence,
+                first_start,
+                best_i,
+                second_sequence,
+                second_start,
+                best_j,
+            ).iter()
+                .cloned(),
+        );
+        let (first_element, second_element) = (
+            first_sequence.at_index(best_i).unwrap(),
+            second_sequence.at_index(best_j).unwrap(),
+        );
         if eqi.is_none() {
             let (mut first_tag, mut second_tag) = (String::new(), String::new());
             let mut cruncher = SequenceMatcher::new(first_element, second_element);
             cruncher.set_is_junk(self.char_junk);
             for opcode in &cruncher.get_opcodes() {
-                let (first_length, second_length) = (opcode.first_end - opcode.first_start,
-                                                     opcode.second_end - opcode.second_start);
+                let (first_length, second_length) = (
+                    opcode.first_end - opcode.first_start,
+                    opcode.second_end - opcode.second_start,
+                );
                 match opcode.tag.as_ref() {
                     "replace" => {
                         first_tag.push_str(&str_with_similar_chars('^', first_length));
@@ -180,42 +195,50 @@ impl Differ {
                     _ => {}
                 }
             }
-            res.extend(self.qformat(&first_element, &second_element, &first_tag, &second_tag)
-                .iter()
-                .cloned());
+            res.extend(
+                self.qformat(&first_element, &second_element, &first_tag, &second_tag)
+                    .iter()
+                    .cloned(),
+            );
         } else {
             let mut s = String::from("  ");
             s.push_str(&first_element);
             res.push(s);
         }
-        res.extend(self.fancy_helper(first_sequence,
-                          best_i + 1,
-                          first_end,
-                          second_sequence,
-                          best_j + 1,
-                          second_end)
-            .iter()
-            .cloned());
+        res.extend(
+            self.fancy_helper(
+                first_sequence,
+                best_i + 1,
+                first_end,
+                second_sequence,
+                best_j + 1,
+                second_end,
+            ).iter()
+                .cloned(),
+        );
         res
     }
 
-    fn fancy_helper<T: ?Sized + Sequence>(&self,
-                                          first_sequence: &T,
-                                          first_start: usize,
-                                          first_end: usize,
-                                          second_sequence: &T,
-                                          second_start: usize,
-                                          second_end: usize)
-                                          -> Vec<String> {
+    fn fancy_helper<T: ?Sized + Sequence>(
+        &self,
+        first_sequence: &T,
+        first_start: usize,
+        first_end: usize,
+        second_sequence: &T,
+        second_start: usize,
+        second_end: usize,
+    ) -> Vec<String> {
         let mut res = Vec::new();
         if first_start < first_end {
             if second_start < second_end {
-                res = self.fancy_replace(first_sequence,
-                                         first_start,
-                                         first_end,
-                                         second_sequence,
-                                         second_start,
-                                         second_end);
+                res = self.fancy_replace(
+                    first_sequence,
+                    first_start,
+                    first_end,
+                    second_sequence,
+                    second_start,
+                    second_end,
+                );
             } else {
                 res = self.dump("-", first_sequence, first_start, first_end);
             }
@@ -225,17 +248,20 @@ impl Differ {
         res
     }
 
-    fn qformat(&self,
-               first_line: &str,
-               second_line: &str,
-               first_tags: &str,
-               second_tags: &str)
-               -> Vec<String> {
+    fn qformat(
+        &self,
+        first_line: &str,
+        second_line: &str,
+        first_tags: &str,
+        second_tags: &str,
+    ) -> Vec<String> {
         let mut res = Vec::new();
         let mut first_tags = first_tags;
         let mut second_tags = second_tags;
-        let mut common = cmp::min(count_leading(first_line, '\t'),
-                                  count_leading(second_line, '\t'));
+        let mut common = cmp::min(
+            count_leading(first_line, '\t'),
+            count_leading(second_line, '\t'),
+        );
         common = cmp::min(common, count_leading(first_tags.split_at(common).0, ' '));
         common = cmp::min(common, count_leading(first_tags.split_at(common).0, ' '));
         first_tags = first_tags.split_at(common).1.trim_right();
@@ -243,15 +269,21 @@ impl Differ {
         let mut s = String::from(format!("- {}", first_line));
         res.push(s);
         if first_tags != "" {
-            s = String::from(format!("? {}{}\n", str_with_similar_chars('\t', common), first_tags));
+            s = String::from(format!(
+                "? {}{}\n",
+                str_with_similar_chars('\t', common),
+                first_tags
+            ));
             res.push(s);
         }
         s = String::from(format!("+ {}", second_line));
         res.push(s);
         if second_tags != "" {
-            s = String::from(format!("? {}{}\n",
-                                     str_with_similar_chars('\t', common),
-                                     second_tags));
+            s = String::from(format!(
+                "? {}{}\n",
+                str_with_similar_chars('\t', common),
+                second_tags
+            ));
             res.push(s);
         }
         res
@@ -283,19 +315,31 @@ impl Differ {
 #[test]
 fn test_fancy_replace() {
     let differ = Differ::new();
-    let result = differ.fancy_replace(&vec!["abcDefghiJkl\n"], 0, 1, &vec!["abcdefGhijkl\n"], 0, 1)
+    let result = differ
+        .fancy_replace(&vec!["abcDefghiJkl\n"], 0, 1, &vec!["abcdefGhijkl\n"], 0, 1)
         .join("");
-    assert_eq!(result,
-               "- abcDefghiJkl\n?    ^  ^  ^\n+ abcdefGhijkl\n?    ^  ^  ^\n");
+    assert_eq!(
+        result,
+        "- abcDefghiJkl\n?    ^  ^  ^\n+ abcdefGhijkl\n?    ^  ^  ^\n"
+    );
 }
 
 #[test]
 fn test_qformat() {
     let differ = Differ::new();
-    let result = differ.qformat("\tabcDefghiJkl\n",
-                                "\tabcdefGhijkl\n",
-                                "  ^ ^  ^      ",
-                                "  ^ ^  ^      ");
-    assert_eq!(result,
-               vec!["- \tabcDefghiJkl\n", "? \t ^ ^  ^\n", "+ \tabcdefGhijkl\n", "? \t ^ ^  ^\n"]);
+    let result = differ.qformat(
+        "\tabcDefghiJkl\n",
+        "\tabcdefGhijkl\n",
+        "  ^ ^  ^      ",
+        "  ^ ^  ^      ",
+    );
+    assert_eq!(
+        result,
+        vec![
+            "- \tabcDefghiJkl\n",
+            "? \t ^ ^  ^\n",
+            "+ \tabcdefGhijkl\n",
+            "? \t ^ ^  ^\n",
+        ]
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub fn context_diff<T: Sequence>(
                     for i in opcode.first_start..opcode.first_end {
                         res.push(format!(
                             "{}{}",
-                            prefix.get(&opcode.tag).unwrap(),
+                            &prefix[&opcode.tag],
                             first_sequence.at_index(i).unwrap()
                         ));
                     }
@@ -144,7 +144,7 @@ pub fn context_diff<T: Sequence>(
                     for i in opcode.second_start..opcode.second_end {
                         res.push(format!(
                             "{}{}",
-                            prefix.get(&opcode.tag).unwrap(),
+                            &prefix[&opcode.tag],
                             second_sequence.at_index(i).unwrap()
                         ));
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@ pub fn get_close_matches<'a>(
         panic!("Cutoff must be greater than 0.0 and lower than 1.0");
     }
     let mut res: Vec<(f32, &str)> = Vec::new();
-    let mut matcher = SequenceMatcher::new(b"", word.as_bytes());
+    let mut matcher = SequenceMatcher::new("", word);
     for i in &possibilities {
-        matcher.set_first_seq(i.as_bytes());
+        matcher.set_first_seq(i);
         let ratio = matcher.ratio();
         if ratio >= cutoff {
             res.push((ratio, i));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,17 @@
-pub mod sequencematcher;
 pub mod differ;
+pub mod sequencematcher;
 mod utils;
 
-
+use sequencematcher::{Sequence, SequenceMatcher};
 use std::collections::HashMap;
-use sequencematcher::{SequenceMatcher, Sequence};
-use utils::{format_range_unified, format_range_context};
+use utils::{format_range_context, format_range_unified};
 
-
-pub fn get_close_matches<'a>(word: &str,
-                             possibilities: Vec<&'a str>,
-                             n: usize,
-                             cutoff: f32)
-                             -> Vec<&'a str> {
+pub fn get_close_matches<'a>(
+    word: &str,
+    possibilities: Vec<&'a str>,
+    n: usize,
+    cutoff: f32,
+) -> Vec<&'a str> {
     if !(0.0 <= cutoff && cutoff <= 1.0) {
         panic!("Cutoff must be greater than 0.0 and lower than 1.0");
     }
@@ -30,14 +29,15 @@ pub fn get_close_matches<'a>(word: &str,
     res.iter().map(|x| x.1).collect()
 }
 
-pub fn unified_diff<T: Sequence>(first_sequence: &T,
-                                 second_sequence: &T,
-                                 from_file: &str,
-                                 to_file: &str,
-                                 from_file_date: &str,
-                                 to_file_date: &str,
-                                 n: usize)
-                                 -> Vec<String> {
+pub fn unified_diff<T: Sequence>(
+    first_sequence: &T,
+    second_sequence: &T,
+    from_file: &str,
+    to_file: &str,
+    from_file_date: &str,
+    to_file_date: &str,
+    n: usize,
+) -> Vec<String> {
     let mut res = Vec::new();
     let lineterm = '\n';
     let mut started = false;
@@ -53,7 +53,10 @@ pub fn unified_diff<T: Sequence>(first_sequence: &T,
         let (first, last) = (group.first().unwrap(), group.last().unwrap());
         let file1_range = format_range_unified(first.first_start, last.first_end);
         let file2_range = format_range_unified(first.second_start, last.second_end);
-        res.push(format!("@@ -{} +{} @@{}", file1_range, file2_range, lineterm));
+        res.push(format!(
+            "@@ -{} +{} @@{}",
+            file1_range, file2_range, lineterm
+        ));
         for code in group {
             if code.tag == "equal" {
                 for i in code.first_start..code.first_end {
@@ -76,15 +79,15 @@ pub fn unified_diff<T: Sequence>(first_sequence: &T,
     res
 }
 
-
-pub fn context_diff<T: Sequence>(first_sequence: &T,
-                                 second_sequence: &T,
-                                 from_file: &str,
-                                 to_file: &str,
-                                 from_file_date: &str,
-                                 to_file_date: &str,
-                                 n: usize)
-                                 -> Vec<String> {
+pub fn context_diff<T: Sequence>(
+    first_sequence: &T,
+    second_sequence: &T,
+    from_file: &str,
+    to_file: &str,
+    from_file_date: &str,
+    to_file_date: &str,
+    n: usize,
+) -> Vec<String> {
     let mut res = Vec::new();
     let lineterm = '\n';
     let mut prefix: HashMap<String, String> = HashMap::new();
@@ -117,9 +120,11 @@ pub fn context_diff<T: Sequence>(first_sequence: &T,
             for opcode in group {
                 if opcode.tag != "insert" {
                     for i in opcode.first_start..opcode.first_end {
-                        res.push(format!("{}{}",
-                                         prefix.get(&opcode.tag).unwrap(),
-                                         first_sequence.at_index(i).unwrap()));
+                        res.push(format!(
+                            "{}{}",
+                            prefix.get(&opcode.tag).unwrap(),
+                            first_sequence.at_index(i).unwrap()
+                        ));
                     }
                 }
             }
@@ -137,9 +142,11 @@ pub fn context_diff<T: Sequence>(first_sequence: &T,
             for opcode in group {
                 if opcode.tag != "delete" {
                     for i in opcode.second_start..opcode.second_end {
-                        res.push(format!("{}{}",
-                                         prefix.get(&opcode.tag).unwrap(),
-                                         second_sequence.at_index(i).unwrap()));
+                        res.push(format!(
+                            "{}{}",
+                            prefix.get(&opcode.tag).unwrap(),
+                            second_sequence.at_index(i).unwrap()
+                        ));
                     }
                 }
             }

--- a/src/sequencematcher.rs
+++ b/src/sequencematcher.rs
@@ -1,5 +1,5 @@
 use std::cmp::{max, min};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use utils::calculate_ratio;
 
@@ -159,29 +159,20 @@ impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
                 .or_insert(Vec::new());
             counter.push(i);
         }
-        if self.is_junk.is_some() {
-            let mut junk = Vec::new();
-            for element in second_sequence_elements.keys() {
-                if (self.is_junk.unwrap())(element) {
-                    junk.push(element.clone());
-                }
-            }
-            for element in &junk {
-                second_sequence_elements.remove(element);
-            }
+        if let Some(junk_func) = self.is_junk {
+            second_sequence_elements = second_sequence_elements
+                .into_iter()
+                .filter(|&(element, _)| !junk_func(element))
+                .collect();
         }
-        let mut popular = HashSet::new();
+        // Filter out popular elements
         let len = second_sequence.len();
         if len >= 200 {
             let test_len = (len as f32 / 100.0).floor() as usize + 1;
-            for (element, indexes) in second_sequence_elements.iter() {
-                if indexes.len() > test_len {
-                    popular.insert(element.clone());
-                }
-            }
-            for element in &popular {
-                second_sequence_elements.remove(element);
-            }
+            second_sequence_elements = second_sequence_elements
+                .into_iter()
+                .filter(|&(_, ref indexes)| indexes.len() > test_len)
+                .collect();
         }
         self.second_sequence_elements = second_sequence_elements;
     }

--- a/src/sequencematcher.rs
+++ b/src/sequencematcher.rs
@@ -111,7 +111,6 @@ pub struct SequenceMatcher<'a, T: 'a + ?Sized + Sequence> {
     opcodes: Option<Vec<Opcode>>,
     is_junk: Option<fn(&str) -> bool>,
     second_sequence_elements: HashMap<&'a str, Vec<usize>>,
-    second_sequence_popular: HashSet<&'a str>,
 }
 
 impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
@@ -123,7 +122,6 @@ impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
             opcodes: None,
             is_junk: None,
             second_sequence_elements: HashMap::new(),
-            second_sequence_popular: HashSet::new(),
         };
         matcher.set_seqs(first_sequence, second_sequence);
         matcher
@@ -186,7 +184,6 @@ impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
             }
         }
         self.second_sequence_elements = second_sequence_elements;
-        self.second_sequence_popular = popular;
     }
 
     pub fn find_longest_match(

--- a/src/sequencematcher.rs
+++ b/src/sequencematcher.rs
@@ -347,12 +347,12 @@ impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
         }
 
         if codes.first().unwrap().tag == "equal" {
-            let mut opcode = codes.first_mut().unwrap();
+            let opcode = codes.first_mut().unwrap();
             opcode.first_start = max(opcode.first_start, opcode.first_end.saturating_sub(n));
             opcode.second_start = max(opcode.second_start, opcode.second_end.saturating_sub(n));
         }
         if codes.last().unwrap().tag == "equal" {
-            let mut opcode = codes.last_mut().unwrap();
+            let opcode = codes.last_mut().unwrap();
             opcode.first_end = min(opcode.first_start + n, opcode.first_end);
             opcode.second_end = min(opcode.second_start + n, opcode.second_end);
         }

--- a/src/sequencematcher.rs
+++ b/src/sequencematcher.rs
@@ -104,6 +104,19 @@ impl<'a> Sequence for Vec<String> {
     }
 }
 
+impl<'a> Sequence for [&'a str] {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn at_index(&self, index: usize) -> Option<&str> {
+        if index < self.len() {
+            return Some(self[index]);
+        }
+        None
+    }
+}
+
 pub struct SequenceMatcher<'a, T: 'a + ?Sized + Sequence> {
     first_sequence: &'a T,
     second_sequence: &'a T,

--- a/src/sequencematcher.rs
+++ b/src/sequencematcher.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet};
 use std::cmp::{max, min};
-use utils::calculate_ratio;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
+use utils::calculate_ratio;
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct Match {
@@ -30,12 +30,13 @@ pub struct Opcode {
 }
 
 impl Opcode {
-    fn new(tag: String,
-           first_start: usize,
-           first_end: usize,
-           second_start: usize,
-           second_end: usize)
-           -> Opcode {
+    fn new(
+        tag: String,
+        first_start: usize,
+        first_end: usize,
+        second_start: usize,
+        second_end: usize,
+    ) -> Opcode {
         Opcode {
             tag: tag,
             first_start: first_start,
@@ -113,7 +114,6 @@ pub struct SequenceMatcher<'a, T: 'a + ?Sized + Sequence> {
     second_sequence_popular: HashSet<&'a str>,
 }
 
-
 impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
     pub fn new(first_sequence: &'a T, second_sequence: &'a T) -> SequenceMatcher<'a, T> {
         let mut matcher = SequenceMatcher {
@@ -156,7 +156,8 @@ impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
         let second_sequence = self.second_sequence;
         let mut second_sequence_elements = HashMap::new();
         for i in 0..second_sequence.len() {
-            let mut counter = second_sequence_elements.entry(second_sequence.at_index(i).unwrap())
+            let mut counter = second_sequence_elements
+                .entry(second_sequence.at_index(i).unwrap())
                 .or_insert(Vec::new());
             counter.push(i);
         }
@@ -188,12 +189,13 @@ impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
         self.second_sequence_popular = popular;
     }
 
-    pub fn find_longest_match(&self,
-                              first_start: usize,
-                              first_end: usize,
-                              second_start: usize,
-                              second_end: usize)
-                              -> Match {
+    pub fn find_longest_match(
+        &self,
+        first_start: usize,
+        first_end: usize,
+        second_start: usize,
+        second_end: usize,
+    ) -> Match {
         let first_sequence = &self.first_sequence;
         let second_sequence = &self.second_sequence;
         let second_sequence_elements = &self.second_sequence_elements;
@@ -234,15 +236,18 @@ impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
             j2len = new_j2len;
         }
         for _ in 0..2 {
-            while best_i > first_start && best_j > second_start &&
-                  first_sequence.at_index(best_i - 1) == second_sequence.at_index(best_j - 1) {
+            while best_i > first_start
+                && best_j > second_start
+                && first_sequence.at_index(best_i - 1) == second_sequence.at_index(best_j - 1)
+            {
                 best_i = best_i - 1;
                 best_j = best_j - 1;
                 best_size = best_size + 1;
             }
-            while best_i + best_size < first_end && best_j + best_size < second_end &&
-                  first_sequence.at_index(best_i + best_size) ==
-                  second_sequence.at_index(best_j + best_size) {
+            while best_i + best_size < first_end && best_j + best_size < second_end
+                && first_sequence.at_index(best_i + best_size)
+                    == second_sequence.at_index(best_j + best_size)
+            {
                 best_size += 1;
             }
         }
@@ -266,10 +271,12 @@ impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
                         queue.push((first_start, m.first_start, second_start, m.second_start));
                     }
                     if m.first_start + m.size < first_end && m.second_start + m.size < second_end {
-                        queue.push((m.first_start + m.size,
-                                    first_end,
-                                    m.second_start + m.size,
-                                    second_end));
+                        queue.push((
+                            m.first_start + m.size,
+                            first_end,
+                            m.second_start + m.size,
+                            second_end,
+                        ));
                     }
                     matches.push(m);
                 }
@@ -319,9 +326,13 @@ impl<'a, T: ?Sized + Sequence> SequenceMatcher<'a, T> {
             i = m.first_start + m.size;
             j = m.second_start + m.size;
             if m.size != 0 {
-                opcodes.push(
-Opcode::new(String::from("equal"), m.first_start, i, m.second_start, j)
-);
+                opcodes.push(Opcode::new(
+                    String::from("equal"),
+                    m.first_start,
+                    i,
+                    m.second_start,
+                    j,
+                ));
             }
         }
         self.opcodes = Some(opcodes);
@@ -350,21 +361,25 @@ Opcode::new(String::from("equal"), m.first_start, i, m.second_start, j)
         for code in &codes {
             let (mut first_start, mut second_start) = (code.first_start, code.second_start);
             if code.tag == "equal" && code.first_end - code.first_start > nn {
-                group.push(Opcode::new(code.tag.clone(),
-                                       code.first_start,
-                                       min(code.first_end, code.first_start + n),
-                                       code.second_start,
-                                       min(code.second_end, code.second_start + n)));
+                group.push(Opcode::new(
+                    code.tag.clone(),
+                    code.first_start,
+                    min(code.first_end, code.first_start + n),
+                    code.second_start,
+                    min(code.second_end, code.second_start + n),
+                ));
                 res.push(group.clone());
                 group.clear();
                 first_start = max(first_start, code.first_end.saturating_sub(n));
                 second_start = max(second_start, code.second_end.saturating_sub(n));
             }
-            group.push(Opcode::new(code.tag.clone(),
-                                   first_start,
-                                   code.first_end,
-                                   second_start,
-                                   code.second_end));
+            group.push(Opcode::new(
+                code.tag.clone(),
+                first_start,
+                code.first_end,
+                second_start,
+                code.second_end,
+            ));
         }
         if !group.is_empty() && !(group.len() == 1 && group.first().unwrap().tag == "equal") {
             res.push(group.clone());
@@ -373,8 +388,12 @@ Opcode::new(String::from("equal"), m.first_start, i, m.second_start, j)
     }
 
     pub fn ratio(&mut self) -> f32 {
-        let matches = self.get_matching_blocks().iter().fold(0, |res, &m| res + m.size);
-        calculate_ratio(matches,
-                        self.first_sequence.len() + self.second_sequence.len())
+        let matches = self.get_matching_blocks()
+            .iter()
+            .fold(0, |res, &m| res + m.size);
+        calculate_ratio(
+            matches,
+            self.first_sequence.len() + self.second_sequence.len(),
+        )
     }
 }

--- a/src/sequencematcher.rs
+++ b/src/sequencematcher.rs
@@ -60,10 +60,13 @@ pub struct SequenceMatcher<'a, T: 'a + Sequence> {
 }
 
 impl<'a, T: Sequence> SequenceMatcher<'a, T> {
-    pub fn new(first_sequence: &'a [T], second_sequence: &'a [T]) -> SequenceMatcher<'a, T> {
+    pub fn new<S>(first_sequence: &'a S, second_sequence: &'a S) -> SequenceMatcher<'a, T>
+    where
+        S: AsRef<[T]> + ?Sized,
+    {
         let mut matcher = SequenceMatcher {
-            first_sequence,
-            second_sequence,
+            first_sequence: first_sequence.as_ref(),
+            second_sequence: second_sequence.as_ref(),
             matching_blocks: None,
             opcodes: None,
             is_junk: None,
@@ -75,22 +78,33 @@ impl<'a, T: Sequence> SequenceMatcher<'a, T> {
 
     pub fn set_is_junk(&mut self, is_junk: Option<fn(&T) -> bool>) {
         self.is_junk = is_junk;
-        self.set_second_seq(self.second_sequence);
+        self.matching_blocks = None;
+        self.opcodes = None;
+        self.chain_second_seq();
     }
 
-    pub fn set_seqs(&mut self, first_sequence: &'a [T], second_sequence: &'a [T]) {
+    pub fn set_seqs<S>(&mut self, first_sequence: &'a S, second_sequence: &'a S)
+    where
+        S: AsRef<[T]> + ?Sized,
+    {
         self.set_first_seq(first_sequence);
         self.set_second_seq(second_sequence);
     }
 
-    pub fn set_first_seq(&mut self, sequence: &'a [T]) {
-        self.first_sequence = sequence;
+    pub fn set_first_seq<S>(&mut self, sequence: &'a S)
+    where
+        S: AsRef<[T]> + ?Sized,
+    {
+        self.first_sequence = sequence.as_ref();
         self.matching_blocks = None;
         self.opcodes = None;
     }
 
-    pub fn set_second_seq(&mut self, sequence: &'a [T]) {
-        self.second_sequence = sequence;
+    pub fn set_second_seq<S>(&mut self, sequence: &'a S)
+    where
+        S: AsRef<[T]> + ?Sized,
+    {
+        self.second_sequence = sequence.as_ref();
         self.matching_blocks = None;
         self.opcodes = None;
         self.chain_second_seq();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ pub fn calculate_ratio(matches: usize, length: usize) -> f32 {
     if length != 0 {
         return 2.0 * matches as f32 / length as f32;
     }
-    return 1.0;
+    1.0
 }
 
 pub fn str_with_similar_chars(c: char, length: usize) -> String {
@@ -19,7 +19,7 @@ pub fn count_leading(line: &str, c: char) -> usize {
     while (i < n) && line[i] == c {
         i += 1;
     }
-    return i;
+    i
 }
 
 pub fn format_range_unified(start: usize, end: usize) -> String {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,6 @@ pub fn calculate_ratio(matches: usize, length: usize) -> f32 {
     return 1.0;
 }
 
-
 pub fn str_with_similar_chars(c: char, length: usize) -> String {
     let mut s = String::new();
     for _ in 0..length {
@@ -13,7 +12,6 @@ pub fn str_with_similar_chars(c: char, length: usize) -> String {
     }
     s
 }
-
 
 pub fn count_leading(line: &str, c: char) -> usize {
     let (mut i, n) = (0, line.len());
@@ -23,7 +21,6 @@ pub fn count_leading(line: &str, c: char) -> usize {
     }
     return i;
 }
-
 
 pub fn format_range_unified(start: usize, end: usize) -> String {
     let mut beginning = start + 1;
@@ -36,7 +33,6 @@ pub fn format_range_unified(start: usize, end: usize) -> String {
     }
     format!("{},{}", beginning, length)
 }
-
 
 pub fn format_range_context(start: usize, end: usize) -> String {
     let mut beginning = start + 1;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,7 +5,7 @@ use difflib::sequencematcher::{Match, Opcode, SequenceMatcher};
 
 #[test]
 fn test_longest_match() {
-    let matcher = SequenceMatcher::new(" abcd", "abcd abcd");
+    let matcher = SequenceMatcher::new(b" abcd", b"abcd abcd");
     let m = matcher.find_longest_match(0, 5, 0, 9);
     assert_eq!(m.first_start, 0);
     assert_eq!(m.second_start, 4);
@@ -14,7 +14,7 @@ fn test_longest_match() {
 
 #[test]
 fn test_all_matches() {
-    let mut matcher = SequenceMatcher::new("abxcd", "abcd");
+    let mut matcher = SequenceMatcher::new(b"abxcd", b"abcd");
     let result = matcher.get_matching_blocks();
     let mut expected_result = Vec::new();
     expected_result.push(Match {
@@ -37,7 +37,7 @@ fn test_all_matches() {
 
 #[test]
 fn test_get_opcodes() {
-    let mut matcher = SequenceMatcher::new("qabxcd", "abycdf");
+    let mut matcher = SequenceMatcher::new(b"qabxcd", b"abycdf");
     let result = matcher.get_opcodes();
     let mut expected_result = Vec::new();
     expected_result.push(Opcode {
@@ -80,7 +80,7 @@ fn test_get_opcodes() {
 
 #[test]
 fn test_ratio() {
-    let mut matcher = SequenceMatcher::new("abcd", "bcde");
+    let mut matcher = SequenceMatcher::new(b"abcd", b"bcde");
     assert_eq!(matcher.ratio(), 0.75);
 }
 
@@ -103,8 +103,8 @@ fn test_differ_compare() {
     );
 }
 
-fn is_junk_char(ch: &str) -> bool {
-    if ch == " " || ch == "\t" {
+fn is_junk_char(ch: &char) -> bool {
+    if *ch == ' ' || *ch == '\t' {
         return true;
     }
     false

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,7 @@
 extern crate difflib;
 
-use difflib::sequencematcher::{SequenceMatcher, Match, Opcode};
 use difflib::differ::Differ;
+use difflib::sequencematcher::{Match, Opcode, SequenceMatcher};
 
 #[test]
 fn test_longest_match() {
@@ -97,8 +97,10 @@ fn test_differ_compare() {
     let second_text = vec!["ore\n", "tree\n", "emu\n"];
     let differ = Differ::new();
     let result = differ.compare(&first_text, &second_text).join("");
-    assert_eq!(result,
-               "- one\n?  ^\n+ ore\n?  ^\n- two\n- three\n?  -\n+ tree\n+ emu\n");
+    assert_eq!(
+        result,
+        "- one\n?  ^\n+ ore\n?  ^\n- two\n- three\n?  -\n+ tree\n+ emu\n"
+    );
 }
 
 fn is_junk_char(ch: &str) -> bool {
@@ -115,8 +117,10 @@ fn test_differ_compare_with_func() {
     let mut differ = Differ::new();
     differ.char_junk = Some(is_junk_char);
     let result = differ.compare(&first_text, &second_text).join("");
-    assert_eq!(result,
-               "- one\n?  ^\n+ ore\n?  ^\n- two\n- three\n?  -\n+ tree\n+ emu\n");
+    assert_eq!(
+        result,
+        "- one\n?  ^\n+ ore\n?  ^\n- two\n- three\n?  -\n+ tree\n+ emu\n"
+    );
 }
 
 #[test]
@@ -133,33 +137,39 @@ fn test_differ_restore() {
 fn test_unified_diff() {
     let first_text = "one two three four".split(" ").collect::<Vec<&str>>();
     let second_text = "zero one tree four".split(" ").collect::<Vec<&str>>();
-    let result = difflib::unified_diff(&first_text,
-                                       &second_text,
-                                       "Original",
-                                       "Current",
-                                       "2005-01-26 23:30:50",
-                                       "2010-04-02 10:20:52",
-                                       3)
-        .join("");
-    assert_eq!(result,
-               "--- Original\t2005-01-26 23:30:50\n+++ Current\t2010-04-02 10:20:52\n@@ -1,4 \
-                +1,4 @@\n+zero one-two-three+tree four");
+    let result = difflib::unified_diff(
+        &first_text,
+        &second_text,
+        "Original",
+        "Current",
+        "2005-01-26 23:30:50",
+        "2010-04-02 10:20:52",
+        3,
+    ).join("");
+    assert_eq!(
+        result,
+        "--- Original\t2005-01-26 23:30:50\n+++ Current\t2010-04-02 10:20:52\n@@ -1,4 \
+         +1,4 @@\n+zero one-two-three+tree four"
+    );
 }
 
 #[test]
 fn test_context_diff() {
     let first_text = "one two three four".split(" ").collect::<Vec<&str>>();
     let second_text = "zero one tree four".split(" ").collect::<Vec<&str>>();
-    let result = difflib::context_diff(&first_text,
-                                       &second_text,
-                                       "Original",
-                                       "Current",
-                                       "2005-01-26 23:30:50",
-                                       "2010-04-02 10:20:52",
-                                       3)
-        .join("");
-    assert_eq!(result,
-               "*** Original\t2005-01-26 23:30:50\n--- Current\t2010-04-02 \
-                10:20:52\n***************\n*** 1,4 ****\n  one! two! three  four--- 1,4 ----\n+ \
-                zero  one! tree  four");
+    let result = difflib::context_diff(
+        &first_text,
+        &second_text,
+        "Original",
+        "Current",
+        "2005-01-26 23:30:50",
+        "2010-04-02 10:20:52",
+        3,
+    ).join("");
+    assert_eq!(
+        result,
+        "*** Original\t2005-01-26 23:30:50\n--- Current\t2010-04-02 \
+         10:20:52\n***************\n*** 1,4 ****\n  one! two! three  four--- 1,4 ----\n+ \
+         zero  one! tree  four"
+    );
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -173,3 +173,22 @@ fn test_context_diff() {
          zero  one! tree  four"
     );
 }
+
+#[test]
+fn test_integer_slice() {
+    let s1 = vec![1, 2, 3, 4, 5];
+    let s2 = vec![5, 4, 3, 2, 1];
+    let result = SequenceMatcher::new(&s1, &s2).get_matching_blocks();
+    let mut expected_result = Vec::new();
+    expected_result.push(Match {
+        first_start: 0,
+        second_start: 4,
+        size: 1,
+    });
+    expected_result.push(Match {
+        first_start: 5,
+        second_start: 5,
+        size: 0,
+    });
+    assert_eq!(result, expected_result);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,7 +5,7 @@ use difflib::sequencematcher::{Match, Opcode, SequenceMatcher};
 
 #[test]
 fn test_longest_match() {
-    let matcher = SequenceMatcher::new(b" abcd", b"abcd abcd");
+    let matcher = SequenceMatcher::new(" abcd", "abcd abcd");
     let m = matcher.find_longest_match(0, 5, 0, 9);
     assert_eq!(m.first_start, 0);
     assert_eq!(m.second_start, 4);
@@ -14,7 +14,7 @@ fn test_longest_match() {
 
 #[test]
 fn test_all_matches() {
-    let mut matcher = SequenceMatcher::new(b"abxcd", b"abcd");
+    let mut matcher = SequenceMatcher::new("abxcd", "abcd");
     let result = matcher.get_matching_blocks();
     let mut expected_result = Vec::new();
     expected_result.push(Match {
@@ -37,7 +37,7 @@ fn test_all_matches() {
 
 #[test]
 fn test_get_opcodes() {
-    let mut matcher = SequenceMatcher::new(b"qabxcd", b"abycdf");
+    let mut matcher = SequenceMatcher::new("qabxcd", "abycdf");
     let result = matcher.get_opcodes();
     let mut expected_result = Vec::new();
     expected_result.push(Opcode {
@@ -80,7 +80,7 @@ fn test_get_opcodes() {
 
 #[test]
 fn test_ratio() {
-    let mut matcher = SequenceMatcher::new(b"abcd", b"bcde");
+    let mut matcher = SequenceMatcher::new("abcd", "bcde");
     assert_eq!(matcher.ratio(), 0.75);
 }
 


### PR DESCRIPTION
As well as other smaller changes that make the code easier to work with.

The only API change that can't be helped are the `line_junk` and `char_junk` function pointers in the Differ struct, which now take  `&&str` and `&char` parameters, respectively. This is probably for the better, since `char_junk` now operates on Unicode scalar values rather than the single UTF-8 bytes disguised as `&str` that were previously retrieved via the unsafe `slice_unchecked()` function.