### PR TITLE
Include LICENSE file in published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 include = [
     "**/*.rs",
     "Cargo.toml",
+    "LICENSE",
 ]
 
 


### PR DESCRIPTION
This PR adds the LICENSE file to the list of files that are included in published crates.

The MIT License requires that a license text is shipped alongside any redistributed sources, for example, those redistributed via crates.io or linux distributions (see, for example, the explanation on [choosealicense.org](https://choosealicense.com/licenses/mit/)). Additionally, there are many recognised, slightly different variants of "the" MIT License (the Fedora Project recognises over 20 different variants [here](https://fedoraproject.org/wiki/Licensing:MIT)), so the only way to really distinguish those is by including the actual license text, as well.